### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/developer.yaml
+++ b/.github/workflows/developer.yaml
@@ -1,4 +1,6 @@
 name: Code Quality
+permissions:
+  contents: read
 on: pull_request
 jobs:
   black:


### PR DESCRIPTION
Potential fix for [https://github.com/splightplatform/splight-agent/security/code-scanning/4](https://github.com/splightplatform/splight-agent/security/code-scanning/4)

In general, the fix is to explicitly restrict the GITHUB_TOKEN permissions using a `permissions:` block, either at the workflow root (applies to all jobs) or individually per job, granting only what is needed. These jobs only need to read repository contents to run code formatters and version checks, so `contents: read` is sufficient.

The best fix here is to add a single top-level `permissions:` block after the `name` (or `on`) key in `.github/workflows/developer.yaml`, setting `contents: read`. This will apply to all three jobs (`black`, `isort`, `verify-version`) that currently lack permissions, without changing their functionality, since they only read repository files. No additional imports, methods, or definitions are needed; this is purely a YAML configuration change within the workflow file.

Concretely: in `.github/workflows/developer.yaml`, between line 1 (`name: Code Quality`) and line 2 (`on: pull_request`), insert:

```yaml
permissions:
  contents: read
```

leaving the rest of the workflow unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
